### PR TITLE
Removal of --api-servers option to Kubelet

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,13 +26,19 @@
     mode: 0644
   tags: kubernetes-config
 
+- name: write kubelet-kubeconfig.yaml
+  template:
+    src: kubelet-kubeconfig.yaml.j2
+    dest: /etc/kubernetes/kubelet-kubeconfig.yaml
+    mode: 0644
+  tags: kubernetes-config
+
 - name: proxy kubeconfig
   template:
     src: proxy-kubeconfig.yaml.j2
     dest: /etc/kubernetes/proxy-kubeconfig.yaml
     mode: 0644
   tags: kubernetes-config
-
 
 - name: Kubelet systemd service
   template:

--- a/templates/kubelet-kubeconfig.yaml.j2
+++ b/templates/kubelet-kubeconfig.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: https://{{ ansible_local.k8s_facts.api_elb }}
+    certificate-authority: /etc/kubernetes/ssl/ca.pem
+users:
+- name: kubelet
+  user:
+    client-certificate: /etc/kubernetes/ssl/worker.pem
+    client-key: /etc/kubernetes/ssl/worker-key.pem
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: kubelet-context
+current-context: kubelet-context

--- a/templates/kubelet.service.j2
+++ b/templates/kubelet.service.j2
@@ -14,7 +14,6 @@ ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/mkdir -p /var/log/containers
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/run/kubelet-pod.uuid
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --api-servers=https://{{ ansible_local.k8s_facts.api_elb }} \
   --cni-conf-dir=/etc/kubernetes/cni/net.d \
   --node-labels={{ node_labels|join(',') }} \
   --network-plugin={{ vars.kubernetes.network_plugin }} \
@@ -27,7 +26,7 @@ ExecStart=/usr/lib/coreos/kubelet-wrapper \
   --cluster_dns={{ vars.kubernetes.dns_service_ip }} \
   --cluster_domain=cluster.local \
   --cloud-provider=aws \
-  --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
+  --kubeconfig=/etc/kubernetes/kubelet-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem
   --v=2


### PR DESCRIPTION
With k8s 1.8 and above --api-servers option has been removed/deprecated in favor of kubeconfig. 